### PR TITLE
Initial Ansible Playbook Setup for Django on EC2

### DIFF
--- a/.github/workflows/setup_with_ansible.yml
+++ b/.github/workflows/setup_with_ansible.yml
@@ -1,0 +1,38 @@
+name: setup with Ansible
+
+on:
+  workflow_dispatch: 
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v2
+
+    - name: Set up Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: '3.8'
+
+    - name: Install Ansible
+      run: |
+        python -m pip install --upgrade pip
+        pip install ansible
+
+    - name: Load Environment Variables
+      run: |
+        echo "EC2_PUBLIC_IP=${{ secrets.SERVER_IP }}" >> $GITHUB_ENV
+        echo "ANSIBLE_USER=${{ secrets.ANSIBLE_USER }}" >> $GITHUB_ENV
+
+    - name: Save Private Key
+      run: |
+        echo "${{ secrets.EC2_PRIVATE_KEY }}" > /tmp/id_rsa
+        chmod 600 /tmp/id_rsa
+
+    
+
+    - name: Run Ansible Playbook
+      run: |
+        ANSIBLE_HOST_KEY_CHECKING=false ansible-playbook -i ansible/hosts.ini ansible/playbooks/initial_setup_django_ec2.yml --private-key /tmp/id_rsa -l webservers

--- a/ansible/ansible.cfg
+++ b/ansible/ansible.cfg
@@ -1,0 +1,2 @@
+[defaults]
+inventory = inventory/hosts.ini

--- a/ansible/inventory/hosts.ini
+++ b/ansible/inventory/hosts.ini
@@ -1,0 +1,2 @@
+[webservers]
+{{ secrets.SERVER_IP }} ansible_user={{ secrets.ANSIBLE_USER }}

--- a/ansible/playbooks/initial_setup_django_ec2.yml
+++ b/ansible/playbooks/initial_setup_django_ec2.yml
@@ -1,0 +1,4 @@
+- hosts: webservers
+  become: true
+  roles:
+    - webserver

--- a/ansible/roles/defaults/main.yml
+++ b/ansible/roles/defaults/main.yml
@@ -1,0 +1,1 @@
+app_dir: /home/ubuntu/mydjangoapp

--- a/ansible/roles/webserver/tasks/main.yml
+++ b/ansible/roles/webserver/tasks/main.yml
@@ -1,0 +1,117 @@
+- name: Update apt packages
+  apt:
+    update_cache: yes
+    force_apt_get: yes
+
+- name: Install system dependencies
+  apt:
+    name:
+      - python3-pip
+      - python3-dev
+      - libpq-dev
+      - git
+      - nginx
+      - virtualenv
+      - python3-venv
+    state: present
+
+- name: Install PostgreSQL
+  apt:
+    name: postgresql
+    state: present
+
+- name: Clone the Django app from GitHub
+  git:
+    repo: "https://github.com/Laban254/ci-test"
+    dest: "{{ app_dir }}"
+    force: yes
+
+- name: Ensure the app directory exists
+  file:
+    path: "{{ app_dir }}"
+    state: directory
+    owner: ubuntu
+    group: www-data
+    mode: '0755'
+
+- name: Create virtual environment
+  command: python3 -m venv {{ app_dir }}/venv
+  args:
+    creates: {{ app_dir }}/venv/bin/activate
+
+- name: Install Python dependencies in the virtual environment
+  pip:
+    requirements: {{ app_dir }}/requirements.txt
+    virtualenv: {{ app_dir }}/venv
+
+- name: Configure Gunicorn
+  copy:
+    dest: /etc/systemd/system/gunicorn.service
+    content: |
+      [Unit]
+      Description=gunicorn daemon for mydjangoapp
+      After=network.target
+
+      [Service]
+      User=ubuntu
+      Group=www-data
+      WorkingDirectory={{ app_dir }}/simple_ci_app
+      ExecStart={{ app_dir }}/venv/bin/gunicorn --workers 3 --bind 0.0.0.0:8000 simple_ci_app.wsgi:application
+      StandardOutput=journal
+      StandardError=journal
+
+      [Install]
+      WantedBy=multi-user.target
+
+- name: Reload systemd to apply changes
+  command: systemctl daemon-reload
+
+- name: Enable and start Gunicorn
+  systemd:
+    name: gunicorn
+    enabled: true
+    state: started
+
+- name: Configure Nginx
+  copy:
+    dest: /etc/nginx/sites-available/mydjangoapp
+    content: |
+      server {
+          listen 80;
+          server_name your_private_ip;  # Replace with your server's private IP
+
+          location / {
+              proxy_pass http://127.0.0.1:8000;
+              proxy_set_header Host $host;
+              proxy_set_header X-Real-IP $remote_addr;
+              proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+              proxy_set_header X-Forwarded-Proto $scheme;
+          }
+
+          location /static/ {
+              alias {{ app_dir }}/static/;
+          }
+
+          location /media/ {
+              alias {{ app_dir }}/media/;
+          }
+
+          access_log /var/log/nginx/mydjangoapp_access.log;
+          error_log /var/log/nginx/mydjangoapp_error.log;
+      }
+
+- name: Enable the Nginx configuration
+  file:
+    src: /etc/nginx/sites-available/mydjangoapp
+    dest: /etc/nginx/sites-enabled/mydjangoapp
+    state: link
+
+- name: Restart Gunicorn
+  systemd:
+    name: gunicorn
+    state: restarted
+
+- name: Restart Nginx
+  systemd:
+    name: nginx
+    state: restarted

--- a/requirements.txt
+++ b/requirements.txt
@@ -23,3 +23,4 @@ sqlparse==0.5.1
 typing_extensions==4.12.2
 uritemplate==4.1.1
 urllib3==2.2.3
+whitenoise==6.7.0


### PR DESCRIPTION
- Set up Ansible playbook for deploying Django application on EC2.
- Added GitHub Actions workflow for Ansible setup.
- Included Whitenoise version 6.7.0 in requirements for static file handling.