### PR TITLE
Add Continuous Deployment Workflow for EC2 Deployment

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -1,0 +1,43 @@
+name: CD
+
+on:
+  push:
+    branches: [deploy]
+    paths-ignore:
+      - "README.md"
+      - ".github/workflows/**"
+  workflow_dispatch:
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: '3.8'
+
+      - name: Save Private Key
+        run: |
+          echo "${{ secrets.ANSIBLE_PRIVATE_KEY }}" > /tmp/id_rsa.pem
+          chmod 600 /tmp/id_rsa.pem
+
+      - name: Deploy to server
+        uses: appleboy/ssh-action@master
+        with:
+          host: ${{ secrets.EC2_PUBLIC_IP }}
+          username: ubuntu
+          key: ${{ secrets.ANSIBLE_PRIVATE_KEY }}
+          script: |
+            git config --global --add safe.directory /home/ubuntu/mydjangoapp
+            cd /home/ubuntu/mydjangoapp
+            git pull origin deploy
+            source venv/bin/activate
+            pip install -r requirements.txt --no-deps --use-deprecated=legacy-resolver
+            python manage.py migrate
+            python manage.py collectstatic --noinput
+            sudo systemctl restart gunicorn

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,3 @@
-# .github/workflows/ci.yml
-
 name: CI
 
 on:

--- a/.github/workflows/setup_with_ansible.yml
+++ b/.github/workflows/setup_with_ansible.yml
@@ -1,4 +1,4 @@
-name: setup with Ansible
+name: initial setup
 
 on:
   workflow_dispatch: 


### PR DESCRIPTION
This PR adds a Continuous Deployment (CD) workflow triggered on the deploy branch to automate deployment to an EC2 instance.

Automated GitHub Actions workflow for EC2:

- Deploys code on push to the `deploy `branch.
- Installs dependencies, applies migrations, and restarts the Gunicorn service.