### PR TITLE
Add Permission Change for .git Directory After Cloning Django App

### DIFF
--- a/ansible/playbooks/initial_setup_django_ec2.yml
+++ b/ansible/playbooks/initial_setup_django_ec2.yml
@@ -29,6 +29,9 @@
         dest: /home/ubuntu/mydjangoapp
         force: yes
 
+    - name: Change permissions for the .git directory
+      command: chmod -R 755 /home/ubuntu/mydjangoapp/.git/
+
     - name: Ensure the app directory exists
       file:
         path: /home/ubuntu/mydjangoapp


### PR DESCRIPTION
Added a task to run chmod -R 755 /home/ubuntu/mydjangoapp/.git/ after the git clone operation.