### PR TITLE
Fix DisallowedHost Error by Updating ALLOWED_HOSTS in Django Settings

### DIFF
--- a/customer_orders_service/settings.py
+++ b/customer_orders_service/settings.py
@@ -28,7 +28,7 @@ SECRET_KEY = 'django-insecure-ex2@pmn$ot7edgieos$lsou$wzfmai4hlh)0pfrwll4ujxx)_f
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = True
 
-ALLOWED_HOSTS = []
+ALLOWED_HOSTS = ['3.87.203.152', 'localhost', '127.0.0.1']
 
 
 # Application definition


### PR DESCRIPTION
solves the DisallowedHost error encountered when accessing the Django application 