### PR TITLE
Fix Permissions for Docker and Git Operations

### DIFF
--- a/ansible/playbooks/install_docker.yml
+++ b/ansible/playbooks/install_docker.yml
@@ -1,10 +1,18 @@
 ---
-- hosts: webservers 
-  become: yes  
+- hosts: webservers
+  become: yes
   tasks:
     - name: Update package list
       apt:
         update_cache: yes
+
+    - name: Ensure correct ownership of the directory
+      file:
+        path: /home/ubuntu/mydjangoapp
+        owner: ubuntu
+        group: ubuntu
+        state: directory
+        mode: '0755'
 
     - name: Clone the Django app from GitHub
       git:
@@ -22,6 +30,17 @@
         name: docker
         state: started
         enabled: yes
+
+    - name: Add user to the docker group
+      user:
+        name: ubuntu
+        groups: docker
+        append: yes
+
+    - name: Restart Docker service to apply group changes
+      systemd:
+        name: docker
+        state: restarted
 
     - name: Install Docker Compose
       shell: |


### PR DESCRIPTION
- Adjust permissions for the /home/ubuntu/mydjangoapp directory to ensure proper access for the ubuntu user.
- Add the ubuntu user to the docker group, enabling the user to run Docker commands without requiring sudo.
- Restart the Docker service to ensure the user group changes take effect.