### PR TITLE
Fix: Ensure Correct Ownership Before Deployment

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -33,6 +33,7 @@ jobs:
           username: ubuntu
           key: ${{ secrets.EC2_PRIVATE_KEY }}
           script: |
+            sudo chown -R ubuntu:ubuntu /home/ubuntu/mydjangoapp
             git config --global --add safe.directory /home/ubuntu/mydjangoapp
             cd /home/ubuntu/mydjangoapp
             git stash -u  


### PR DESCRIPTION
This PR adds a `chown` command to the deployment workflow to set the correct ownership of `/home/ubuntu/mydjangoapp`, preventing permission issues during git pulls.