### PR TITLE
Implement WhiteNoise for Static File Serving in Django

### DIFF
--- a/customer_orders_service/settings.py
+++ b/customer_orders_service/settings.py
@@ -55,6 +55,7 @@ MIDDLEWARE = [
     'whitenoise.middleware.WhiteNoiseMiddleware',
 ]
 
+STATICFILES_STORAGE = 'whitenoise.storage.CompressedManifestStaticFilesStorage'
 ROOT_URLCONF = 'customer_orders_service.urls'
 
 TEMPLATES = [


### PR DESCRIPTION

Updated STATICFILES_STORAGE to use whitenoise.storage.CompressedManifestStaticFilesStorage.