### PR TITLE
Ensure Correct Middleware Order for WhiteNoise in Django Settings

### DIFF
--- a/customer_orders_service/settings.py
+++ b/customer_orders_service/settings.py
@@ -46,13 +46,13 @@ INSTALLED_APPS = [
 
 MIDDLEWARE = [
     'django.middleware.security.SecurityMiddleware',
+    'whitenoise.middleware.WhiteNoiseMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.middleware.common.CommonMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',
     'django.contrib.auth.middleware.AuthenticationMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
-    'whitenoise.middleware.WhiteNoiseMiddleware',
 ]
 
 STATICFILES_STORAGE = 'whitenoise.storage.CompressedManifestStaticFilesStorage'


### PR DESCRIPTION
- Updated the MIDDLEWARE configuration in settings.py to position WhiteNoise immediately after SecurityMiddleware.
- This change ensures proper handling of static file requests by WhiteNoise, which is essential for serving static files effectively.