### PR TITLE
Fix Nginx Configuration for Serving Static Files

### DIFF
--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -14,20 +14,20 @@ http {
         listen 80;
         server_name savannah-informatics.mooo.com 3.208.71.116; 
 
-        location / {
-            proxy_pass http://web;  
-            proxy_set_header Host $host;
-            proxy_set_header X-Real-IP $remote_addr;
-            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-            proxy_set_header X-Forwarded-Proto $scheme;
-        }
-
         location /static/ {
             alias /app/staticfiles/;
         }
 
         location /media/ {
             alias /app/media/; 
+        }
+
+        location / {
+            proxy_pass http://web;  
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
         }
 
         access_log /var/log/nginx/mydjangoapp_access.log;


### PR DESCRIPTION
Updated Nginx configuration to serve static files from /app/staticfiles/ before proxying requests to the Django app. This ensures proper access to static assets