### PR TITLE
Remove STATICFILES_STORAGE Setting to Address Deprecation Warning

### DIFF
--- a/customer_orders_service/settings.py
+++ b/customer_orders_service/settings.py
@@ -28,6 +28,7 @@ SECRET_KEY = 'django-insecure-ex2@pmn$ot7edgieos$lsou$wzfmai4hlh)0pfrwll4ujxx)_f
 # SECURITY WARNING: don't run with debug turned on in production!
 # Set DEBUG based on the environment variable
 DEBUG = os.getenv('DEBUG', 'False') == 'True'
+
 # Set ALLOWED_HOSTS
 ALLOWED_HOSTS = os.getenv('ALLOWED_HOSTS', '').split(',')
 
@@ -56,7 +57,6 @@ MIDDLEWARE = [
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
 ]
 
-STATICFILES_STORAGE = 'whitenoise.storage.CompressedManifestStaticFilesStorage'
 ROOT_URLCONF = 'customer_orders_service.urls'
 
 TEMPLATES = [


### PR DESCRIPTION
Removed the deprecated STATICFILES_STORAGE setting to eliminate warnings and ensure compatibility.