### PR TITLE
Add Nginx Lua script to serve log file content

### DIFF
--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -44,11 +44,34 @@ http {
             proxy_set_header X-Forwarded-Proto $scheme;
         }
 
-        # Serve live logs
-        location /logs/ {
-            alias /app/logs/; 
-            autoindex on;
-            try_files $uri =404;
+        # Serve live logs with Lua
+        location /logs {
+            default_type text/plain;  # Set content type to plain text
+
+            # Lua block to read the last 50 lines of the log file
+            content_by_lua_block {
+                local log_file_path = "/app/logs/~myAppLogs.log"  -- Path to your log file
+
+                local file = io.open(log_file_path, "r")  -- Open the log file for reading
+                if not file then
+                    ngx.say("Log file not found.")  -- Handle case where file does not exist
+                    return
+                end
+
+                local lines = {}  -- Table to store lines from the log file
+                for line in file:lines() do
+                    table.insert(lines, line)  -- Add each line to the table
+                end
+                file:close()  -- Close the file
+
+                -- Get the last 50 lines or all if less than 50
+                local num_lines = #lines
+                local start_line = num_lines > 50 and (num_lines - 49) or 1
+
+                for i = start_line, num_lines do
+                    ngx.say(lines[i])  -- Output the last 50 lines
+                end
+            }
         }
 
         access_log /var/log/nginx/mydjangoapp_access.log;


### PR DESCRIPTION
- Updated the Nginx configuration to include a new location block for `/logs`.
- Implemented a Lua script that reads and outputs the last 50 lines of the specified log file.
- Set the content type for the log output to `text/plain`.